### PR TITLE
Remove . in css classes

### DIFF
--- a/Resources/views/Grid/grid.html.twig
+++ b/Resources/views/Grid/grid.html.twig
@@ -39,7 +39,7 @@
                 {% block kit_grid_tbody_before_column %}{%endblock%}
                 {% for field in grid.gridConfig.fieldList %}
                     {% if field.visible %}
-                        <td class="kit-grid-cell-{{ field.fieldName }}">
+                        <td class="kit-grid-cell-{{ field.fieldName | replace({'.': '-'}) }}">
                             {% if field.translatable %}
                                 {{ grid.displayGridValue ( item, field) | raw | trans }}
                             {% else %}


### PR DESCRIPTION
Added a replace to avoid classes like alias.fieldName in td's css classes.
