### PR TITLE
Added Gedmo translatable compatibility

### DIFF
--- a/Model/GridConfig.php
+++ b/Model/GridConfig.php
@@ -15,6 +15,8 @@ class GridConfig
     protected $fieldList = array();
     /** @var string */
     protected $countFieldName = null;
+    /** @var boolean */
+    protected $useGedmoTranslatable = false;
 
 
     public function addField($field)
@@ -104,6 +106,22 @@ class GridConfig
     public function getCountFieldName()
     {
         return $this->countFieldName;
+    }
+    
+    /**
+     * @param boolean $value
+     */
+    public function useGedmoTranslatable($value)
+    {
+        $this->useGedmoTranslatable = $value;
+    }
+    
+    /**
+     * @return boolean
+     */
+    public function isUsingGedmoTranslatable()
+    {
+        return $this->useGedmoTranslatable;
     }
 
 }

--- a/Service/GridManager.php
+++ b/Service/GridManager.php
@@ -85,6 +85,12 @@ class GridManager
 
         // execute request
         $query = $gridQueryBuilder->getQuery();
+        if($gridConfig->isUsingGedmoTranslatable()) {
+            $query->setHint(
+                \Doctrine\ORM\Query::HINT_CUSTOM_OUTPUT_WALKER,
+                'Gedmo\\Translatable\\Query\\TreeWalker\\TranslationWalker'
+            );
+        }
         $itemList = $query->getArrayResult();
 
         // normalize result (for request of type $queryBuilder->select("item, bp, item.id * 3 as titi"); )


### PR DESCRIPTION
Actually the grid isn't working with the gedmo translatable extension.

So I added the possibility to translate the grid based on the translatableLocale.

Ex in controller : 

$translatable = $this->get('gedmo.listener.translatable');
$translatable->setTranslatableLocale($locale);

$gridConfig = new GridConfig();
$gridConfig->useGedmoTranslatable(true);
