### PR TITLE
Remove groupby DQL part for count query

### DIFF
--- a/Service/GridManager.php
+++ b/Service/GridManager.php
@@ -211,6 +211,7 @@ class GridManager
         $countQueryBuilder->select("count(DISTINCT ".$paginatorConfig->getCountFieldName().")");
         $countQueryBuilder->setMaxResults(null);
         $countQueryBuilder->setFirstResult(null);
+        $countQueryBuilder->resetDQLPart('groupBy');
 
         // event to change paginator query builder
         $event = new DataGridEvent();


### PR DESCRIPTION
If not, query with field used for both group and count failed (too many result exception for count query)
