### PR TITLE
Flatten arrays with one value when normalizing item

### DIFF
--- a/Grid/ItemListNormalizer/StandardNormalizer.php
+++ b/Grid/ItemListNormalizer/StandardNormalizer.php
@@ -62,8 +62,8 @@ class StandardNormalizer
         // and create subAliasList
         $joinAliasList = array();
         $remainingAliasList = array();
-        foreach($aliasList as $aliasKey => $aliasVal) {
-            // si the current key begins by the baseAlias, we have to use it in this hierarchica level
+        foreach ($aliasList as $aliasKey => $aliasVal) {
+            // if the current key begins by the baseAlias, we have to use it in this hierarchical level
             if (strpos($aliasKey, $baseAlias.'.') === 0) {
                 $joinAliasList[ substr( $aliasKey, strlen($baseAlias)+1 ) ] = $aliasVal;
             } else {
@@ -76,7 +76,7 @@ class StandardNormalizer
         // if there is numerical keys in the result, as xxx are alpha numeric keys and
         // the root alias is in the numerical "0" part... oh yeah...
         $containAsSection = false;
-        foreach ($item as $key=>$val) {
+        foreach ($item as $key => $val) {
             if (is_int($key)) {
                 $containAsSection = true;
             }

--- a/Grid/ItemListNormalizer/StandardNormalizer.php
+++ b/Grid/ItemListNormalizer/StandardNormalizer.php
@@ -42,8 +42,16 @@ class StandardNormalizer
         return $normalizedItemList;
     }
 
-
-    protected function normalizeOneItem($aliasList, $item, $baseAlias)
+    /**
+     * Normalize one item
+     *
+     * @param array  $aliasList
+     * @param array  $item
+     * @param string $baseAlias
+     * @param bool   $flattenArray
+     * @return array
+     */
+    protected function normalizeOneItem($aliasList, $item, $baseAlias, $flattenArray = false)
     {
         // case of left join that returns null
         if (is_null($item)) {
@@ -76,14 +84,14 @@ class StandardNormalizer
 
         $valueList = array();
         foreach($item as $key => $val) {
-            if ($key === 0) {
+            if ($key === 0 || $flattenArray) {
                 $valueListToMerge = $this->normalizeOneItem($remainingAliasList, $val, $baseAlias);
                 $valueList = array_merge($valueList, $valueListToMerge);
             } elseif ( is_int($key) && ($key > 0)) {
                 $valueList[$key-1] = $val;
             } elseif ( ! $containAsSection ) {
                 if (array_key_exists($key, $joinAliasList)) {
-                    $valueListToMerge = $this->normalizeOneItem($remainingAliasList, $val, $joinAliasList[$key]);
+                    $valueListToMerge = $this->normalizeOneItem($remainingAliasList, $val, $joinAliasList[$key], count($val) === 1);
                     $valueList = array_merge($valueList, $valueListToMerge);
                 } else {
                     $valueList[$baseAlias.'.'.$key] = $val;


### PR DESCRIPTION
My usecase is the following:
I have a questionnaire which is translated using the PrezentDoctrineTranslatableBundle. My queryBuilder is the following:
``` php
$this->createQueryBuilder('q')
            ->select('q, qt')
            ->join('q.translations', 'qt')
            ->where('qt.locale = :locale')
            ->orderBy('qt.name')
            ->setParameter('locale', $locale);
```
The result, after 'getArrayResult()':
```php
array (size=2)
  'id' => int 4
  'translations' => 
    array (size=1)
      'en' => 
        array (size=4)
          'name' => string 'asdfa' (length=5)
          'description' => string '' (length=0)
          'id' => int 6
          'locale' => string 'en' (length=2)
```
Note that the 'translations' array, is not numerical, but has the locale as its key. This is because the PrezentTranslatable uses an indexBy strategy on 'locale', on the relation between the translatable entity and its translations.

Because of this, the normalized item comes out like:
```php
array (size=2)
  'q.id' => int 4
  'qt.en' => 
    array (size=4)
      'name' => string 'asdfa' (length=5)
      'description' => string '' (length=0)
      'id' => int 6
      'locale' => string 'en' (length=2)
```
instead of 
```php
array (size=5)
  'q.id' => int 4
  'qt.name' => string 'asdfa' (length=5)
  'qt.description' => string '' (length=0)
  'qt.id' => int 6
  'qt.locale' => string 'en' (length=2)
```
This causes the grid to not display a value for i.e. 'qt.name', and also makes it impossible to filter and sort on this field.

The reason for this is that the normalizeOneItem function, only flattens an array if its key is '0'. I thought about this, and I think the same can be done for all arrays with only one value, even if they have an alphanumerical key.
I'm just not sure if this has any side-effects. I haven't encountered any yet, but thats not saying anything, of course.