### PR TITLE
make no-data message overwritable

### DIFF
--- a/Resources/views/Grid/grid.html.twig
+++ b/Resources/views/Grid/grid.html.twig
@@ -67,7 +67,7 @@
             </tr>
         {% else %}
             <tr>
-                <td colspan="{{ grid.gridConfig.fieldList | length }}" class="kit-grid-no-data">{{ "kitpages_data_grid.No-data-found" | trans }}</td>
+                <td colspan="{{ grid.gridConfig.fieldList | length }}" class="kit-grid-no-data">{% block kit_grid_no_data %}{{ "kitpages_data_grid.No_Data_Found" | trans }}{% endblock %}</td>
             </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
Adds a block around the no-data message. Also fixes the wrong translation label
