### PR TITLE
[#42], [#44] Replace hardcoded paginator template, add value attr to the search field

### DIFF
--- a/Resources/views/Grid/bootstrap-grid.html.twig
+++ b/Resources/views/Grid/bootstrap-grid.html.twig
@@ -74,7 +74,7 @@
     </table>
     {{ block('kit_grid_after_table') }}
     {% block kit_grid_paginator %}
-        {% embed 'KitpagesDataGridBundle:Paginator:bootstrap-paginator.html.twig' with {'paginator':grid.paginator} %}
+        {% embed kitpages_data_grid.paginator.default_twig with {'paginator':grid.paginator} %}
         {% endembed %}
     {% endblock %}
     {{ block(' kit_grid_after_paginator') }}

--- a/Resources/views/Grid/bootstrap3-grid.html.twig
+++ b/Resources/views/Grid/bootstrap3-grid.html.twig
@@ -81,7 +81,7 @@
         </table>
         {{ block('kit_grid_after_table') }}
         {% block kit_grid_paginator %}
-            {% embed '::datagrid/bootstrap3-paginator.html.twig' with {'paginator':grid.paginator} %}
+            {% embed kitpages_data_grid.paginator.default_twig with {'paginator':grid.paginator} %}
             {% endembed %}
         {% endblock %}
         {{ block(' kit_grid_after_paginator') }}

--- a/Resources/views/Grid/bootstrap3-grid.html.twig
+++ b/Resources/views/Grid/bootstrap3-grid.html.twig
@@ -19,7 +19,7 @@
                     <div class="form-group">
                         <div class="input-group">
                             <label class="sr-only" for="{{grid.filterFormName}}">{{ "kitpages_data_grid.Filter" | trans }}</label>
-                            <input type="text" class="form-control" id="{{grid.filterFormName}}" name="{{grid.filterFormName}}" placeholder="{{ "kitpages_data_grid.Filter" | trans }}">
+                            <input type="text" class="form-control" id="{{grid.filterFormName}}" value="{{ grid.filterValue }}" name="{{grid.filterFormName}}" placeholder="{{ "kitpages_data_grid.Filter" | trans }}">
                         </div>
                     </div>
                     <button type="submit" class="btn btn-default">{{ "kitpages_data_grid.Apply" | trans }}</button>

--- a/Resources/views/Grid/grid.html.twig
+++ b/Resources/views/Grid/grid.html.twig
@@ -75,7 +75,7 @@
     </table>
     {{ block('kit_grid_after_table') }}
     {% block kit_grid_paginator %}
-        {% embed 'KitpagesDataGridBundle:Paginator:paginator.html.twig' with {'paginator':grid.paginator} %}
+        {% embed kitpages_data_grid.paginator.default_twig with {'paginator':grid.paginator} %}
         {% endembed %}
     {% endblock %}
     {{ block(' kit_grid_after_paginator') }}


### PR DESCRIPTION
It seems that paginator twig template is hardcoded, hence config setting does not do anything.